### PR TITLE
Update bond.py

### DIFF
--- a/ifupdown2/addons/bond.py
+++ b/ifupdown2/addons/bond.py
@@ -65,7 +65,8 @@ class bond(Addon, moduleBase):
                     "1", "layer3+4",
                     "2", "layer2+3",
                     "3", "encap2+3",
-                    "4", "encap3+4"
+                    "4", "encap3+4",
+                    "5", "vlan+srcmac"
                 ],
                 "default": "layer2",
                 "example": ["bond-xmit-hash-policy layer2"]

--- a/ifupdown2/nlmanager/nlpacket.py
+++ b/ifupdown2/nlmanager/nlpacket.py
@@ -536,16 +536,19 @@ class NetlinkPacket_IFLA_LINKINFO_Attributes:
         'layer2+3': 2,
         'encap2+3': 3,
         'encap3+4': 4,
+        'vlan+srcmac': 5,
         '0': 0,
         '1': 1,
         '2': 2,
         '3': 3,
         '4': 4,
+        '5': 5,
         0: 0,
         1: 1,
         2: 2,
         3: 3,
-        4: 4
+        4: 4,
+        5: 5,
     }
 
     ifla_bond_xmit_hash_policy_pretty_tbl = {
@@ -554,6 +557,7 @@ class NetlinkPacket_IFLA_LINKINFO_Attributes:
         2: 'layer2+3',
         3: 'encap2+3',
         4: 'encap3+4',
+        5: 'vlan+srcmac',
     }
 
     ifla_bond_primary_reselect_tbl = {


### PR DESCRIPTION
Add support for xmit-hash-policy 5 - vlan+srcmac, added in Linux 5.12.